### PR TITLE
Add resolving of full photo url

### DIFF
--- a/MessengerChatMediaDownloader/MediaFetcher.ts
+++ b/MessengerChatMediaDownloader/MediaFetcher.ts
@@ -86,7 +86,13 @@ export class MediaFetcher {
                     console.log("Thread name: " + name + ", message count: " + threadInfo.messageCount);
 
                     let urls: string[] = await this.getUrlsForThread(threadInfo, name);
-
+                    for (let i = 0; i < urls.length; i++){
+                        let url = urls[i];
+                        if (!url.includes("https")) {
+                            await delay(random.int(1000, 5000));
+                            urls[i] = await this.getFullPhotoUrl(url);
+                        }
+                    }
                     await this.saveUrlsToDisk(threadId, urls);
                 } else {
                     throw new MediaFetcherError("Failed to query thread info");
@@ -110,7 +116,7 @@ export class MediaFetcher {
     /**
      * Get urls for a given thread.
      * @param threadInfo
-     * @returns 
+     * @returns
      */
     async getUrlsForThread(threadInfo: any, name: string): Promise<string[]> {
         let threadId: string = threadInfo.threadID;
@@ -182,7 +188,7 @@ export class MediaFetcher {
                 msg.attachments.forEach(attachment => {
                     let url = null;
                     if (attachment.type == "photo") {
-                        url = attachment.largePreviewUrl;
+                        url = attachment.ID;
                     }
                     else if (attachment.type == "audio" || attachment.type == "video") {
                         url = attachment.url;
@@ -361,6 +367,20 @@ export class MediaFetcher {
                 }
 
                 resolve(info);
+            });
+        });
+    }
+
+    async getFullPhotoUrl(ID: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            this.facebookApi.resolvePhotoUrl(ID,  (err, url) => {
+                if (err) {
+                    Config.logError(err);
+                    reject(Error("Failed to resolve full photo url"));
+                    return;
+                }
+
+                resolve(url);
             });
         });
     }


### PR DESCRIPTION
## Overview
### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring
- [ ] This change requires a documentation update
### What is the solution?
Added new method getFullPhotoUrl which returns URL of full size picture. Inside getUrlsFromMessage method we are checking if the type of the message is a picture, and then we are saving the ID of picture. This ID is then used in saveUrlsForThread method where we are going through the array of URLs. When URL is not a real url, when it doesn't contain "https" then we are executing our new method getFullPhotoUrl. 

It's important to note that Facebook is eager to temporarily block you for up to 24 hours with message "It looks like you were misusing this feature by going too fast. You’ve been temporarily blocked from using it.". That is why I added random delay of 2 to 5 seconds before executing our new method. this hacky solution have to be tested more thoroughly.

### What are the main changes this MR?
File MediaFetcher.ts was changed.
## Reviewing
### Which order of files makes the most sense for the reviewer?
Have a look at the MediaFetcher.ts.
## Other Notes

